### PR TITLE
Prevent locators from masking ServiceNotFoundExceptions during retrieval

### DIFF
--- a/src/Locator/ClassnameZendLocator.php
+++ b/src/Locator/ClassnameZendLocator.php
@@ -28,11 +28,8 @@ class ClassnameZendLocator implements HandlerLocator
     {
         $handlerFQCN = $commandName . 'Handler';
 
-        try {
+        if ($this->serviceLocator->has($handlerFQCN)) {
             return $this->serviceLocator->get($handlerFQCN);
-        } catch (ServiceNotFoundException $e) {
-            // Further check exists for class availability.
-            // If not, Exception will be thrown anyway.
         }
 
         if (class_exists($handlerFQCN)) {

--- a/src/Locator/ZendLocator.php
+++ b/src/Locator/ZendLocator.php
@@ -35,11 +35,8 @@ class ZendLocator implements HandlerLocator
 
         $serviceNameOrFQCN = $this->handlerMap[$commandName];
 
-        try {
+        if ($this->serviceLocator->has($serviceNameOrFQCN)) {
             return $this->serviceLocator->get($serviceNameOrFQCN);
-        } catch (ServiceNotFoundException $e) {
-            // Further check exists for class availability.
-            // If not, Exception will be thrown anyway.
         }
 
         if (class_exists($serviceNameOrFQCN)) {


### PR DESCRIPTION
I found an issue where even though the Service Locator had a pointer to the desired handler it would still throw a ServiceNotFoundException while trying to retrieve undefined dependencies. This made the error of "handler not found" confusing because it actually did exist and the Service Locator did actually try to create the handler but the problem was farther down.

This way the container can define whether it can create the handler and if there's an error down the pipeline it will be thrown with greater clarity. If it doesn't know about the handler it can flow down into the MissingHandlerException confidently.
